### PR TITLE
Regex performance enhancement

### DIFF
--- a/Runtime/Bindings/RegexFactory.cs
+++ b/Runtime/Bindings/RegexFactory.cs
@@ -4,11 +4,7 @@ namespace TechTalk.SpecFlow.Bindings
 {
     internal static class RegexFactory
     {
-#if SILVERLIGHT
         private static RegexOptions RegexOptions = RegexOptions.CultureInvariant;
-#else
-        private static RegexOptions RegexOptions = RegexOptions.Compiled | RegexOptions.CultureInvariant;
-#endif
 
         public static Regex Create(string regexString)
         {


### PR DESCRIPTION
As the number of step definitions becomes sufficiently high (thousands) we hit a performance issue, i.e., heavy startup (in terms of CPU and memory consumption) whereas the performance gains from faster execution speeds of the compiled regexes remain hardly noticeable. 
Removing Compiled regex option resolves the issue.
